### PR TITLE
fix: add ijson to install_requires

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -8,7 +8,7 @@ def read_file(fname):
 
 setup(
     name="spider-client",
-    version="0.1.22",
+    version="0.1.23",
     url="https://github.com/spider-rs/spider-clients/tree/main/python",
     author="Spider",
     author_email="jeff@spider.cloud",

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email="jeff@spider.cloud",
     description="Python SDK for Spider Cloud API",
     packages=find_packages(),
-    install_requires=["requests"],
+    install_requires=["requests", "ijson"],
     long_description=read_file("README.md"),
     long_description_content_type="text/markdown",
     classifiers=[


### PR DESCRIPTION
We're users of this and hit an error about ijson. I added it to our local requirements.txt and that fixed it, but I think this needs to be added here. I'm far from an expert on python packages, so if I'm mistaken please let me know.