### PR TITLE
fix(python): removed pipe operator

### DIFF
--- a/python/spider/spider_types.py
+++ b/python/spider/spider_types.py
@@ -157,7 +157,10 @@ class RequestParamsDict(TypedDict, total=False):
 
     # The format in which the result should be returned.
     return_format: Optional[
-       ReturnFormat | List[ReturnFormat]
+       Union[
+           ReturnFormat,
+           List[ReturnFormat],
+       ]
     ]
 
     # Specifies whether to only visit the top-level domain.


### PR DESCRIPTION
There's one pipe operator used instead of Union in `spider_types.py`, which breaks compatibility with Python 3.9.